### PR TITLE
Fix version number parsing in the event of two digits minor

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,7 @@
 
 - name: ORACLE_INSTANT_CLIENT | Simbolic link to installation folder
   file:
-   src: "{{ instant_client_root_path }}_{{ instant_client_version[0:2] }}_{{ instant_client_version[3] }}"
+   src: "{{ instant_client_root_path }}_{{ instant_client_version.split('.')[0] }}_{{ instant_client_version.split('.')[1] }}"
    dest: "{{ instant_client_root_path }}"
    state: link
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

I simply added a `split` at version number parsing instead of cutting the string at character positions.

Please note that Oracle also changed the URL path, adding a "0", so I had to add this hack in my site.yml:

      instant_client_version: 19.19.0.0.0.0
      instant_client_basic_release_name: instantclient-basic-{{ instant_client_release_system }}-19.19.0.0.0dbru
      instant_client_devel_release_name: instantclient-sdk-{{ instant_client_release_system }}-19.19.0.0.0dbru
      instant_client_sqlplus_release_name: instantclient-sqlplus-{{ instant_client_release_system }}-19.19.0.0.0dbru

### Benefits

Oracle released new Instant Client versions with a two-digits minor number (i.e. 19.19.0.0.0 or 21.10.0.0.0), this patch makes those numbers parsable.

### Possible Drawbacks

None?

### Applicable Issues

N/A